### PR TITLE
Update spikeAndSlab.R

### DIFF
--- a/R/spikeAndSlab.R
+++ b/R/spikeAndSlab.R
@@ -803,6 +803,7 @@ spikeAndSlab <- function(
     })
   }
 
+  ret$X <- ret$X[, model$reverseOrder]
 
   ret$fitted <- cbind(eta = ret$X %*% ret$postMeans$beta)
   ret$fitted <- cbind(eta = ret$fitted, mu = switch(familystr,
@@ -810,21 +811,18 @@ spikeAndSlab <- function(
     binomial = plogis(ret$fitted),
     poisson =  exp(ret$fitted)))
 
-
   ret$DIC <- {
     Dbar <- -2 * mean(unlist(ret$samples$logLik), na.rm = T)
     Dhat <- -2 * switch(familystr,
-      gaussian = sum(dnorm(y - X %*% ret$postMeans$beta, mean = 0,
+      gaussian = sum(dnorm(y - ret$X %*% ret$postMeans$beta, mean = 0,
         sd = sqrt(ret$postMeans$sigma2), log = T)),
       binomial = sum(dbinom(y * model$scale, model$scale,
-        plogis(X %*% ret$postMeans$beta), log = T)),
-      poisson =  sum(dpois(y, exp(X %*% ret$postMeans$beta), log = T)))
+        plogis(ret$X %*% ret$postMeans$beta), log = T)),
+      poisson =  sum(dpois(y, exp(ret$X %*% ret$postMeans$beta), log = T)))
     pD <- Dbar - Dhat
     DIC <- pD + Dbar
     c(DIC = DIC, pD = pD, Dbar = Dbar, Dhat = Dhat)
   }
-
-  ret$X <- ret$X[, model$reverseOrder]
 
   if(mcmc$reduceRet) {
     ret$data <- NULL


### PR DESCRIPTION
The columns of X should be reordered before calculating fitted values and DIC. The following code could be included in a tests directory to indicate the problem with the current implementation and to check that the problem is solved after making the changes:

suppressMessages(library("spikeSlabGAM"))
set.seed(1234)
x1 <- seq(0, 1, length.out = 100)
x2 <- runif(length(x1))
y <- rnorm(length(x1), sin(2 * pi * x1), 0.1)
df <- data.frame(y = y, x1 = x1, x2 = x2)
modelfit <- spikeSlabGAM(y ~ x1 + x2, data = df)
fitted <- modelfit$fitted[, 1]
predicted <- as.numeric(predict(modelfit)[, "eta"])
stopifnot(isTRUE(all.equal(fitted, predicted)))